### PR TITLE
Catch the type mismatch.

### DIFF
--- a/main.py
+++ b/main.py
@@ -139,7 +139,7 @@ def create_tx(ctx, p2sh_address, recipient_list_file, hexadecimal_tx_file):
     fee = Decimal('1')  # TODO: implement fee estimator
     balance = Decimal(f"{sum(map(lambda x: x['amount'], uxtos)):.9f}")
     total_amount = sum(recipients.values())
-    charge = balance - total_amount - fee
+    balance = Decimal(sum(map(lambda x: x['amount'], uxtos)))
 
     if charge < 0:
         click.echo(click.style(f'Insufficient balance: {balance} < {total_amount} + {fee}', fg='red'))


### PR DESCRIPTION
Traceback (most recent call last):
  File "main.py", line 296, in <module>
    CLI()
  File "C:\Python36\lib\site-packages\click\core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "C:\Python36\lib\site-packages\click\core.py", line 697, in main
    rv = self.invoke(ctx)
  File "C:\Python36\lib\site-packages\click\core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "C:\Python36\lib\site-packages\click\core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\Python36\lib\site-packages\click\core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "C:\Python36\lib\site-packages\click\decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "main.py", line 142, in create_tx
    charge = balance - total_amount - fee
TypeError: unsupported operand type(s) for -: 'float' and 'decimal.Decimal'